### PR TITLE
refactor: centralize bearer authentication and simplify API service

### DIFF
--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/auth/core/data/datasource/AuthRemoteDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/auth/core/data/datasource/AuthRemoteDataSourceImpl.kt
@@ -4,7 +4,6 @@ import id.my.sendiko.fintrack.auth.login.data.dto.LoginRequest
 import id.my.sendiko.fintrack.auth.login.data.dto.LoginResponse
 import id.my.sendiko.fintrack.auth.register.data.dto.RegisterRequest
 import id.my.sendiko.fintrack.auth.register.data.dto.RegisterResponse
-import id.my.sendiko.fintrack.core.network.BASE_URL
 import id.my.sendiko.fintrack.core.network.safeCall
 import id.my.sendiko.fintrack.core.network.utils.DataError
 import id.my.sendiko.fintrack.core.network.utils.Result
@@ -17,7 +16,7 @@ class AuthRemoteDataSourceImpl(
 ) : AuthRemoteDataSource {
     override suspend fun register(request: RegisterRequest): Result<RegisterResponse, DataError.Remote> {
         return safeCall<RegisterResponse> {
-            client.post("$BASE_URL/register") {
+            client.post("register") {
                 setBody(request)
             }
         }
@@ -25,7 +24,7 @@ class AuthRemoteDataSourceImpl(
 
     override suspend fun login(request: LoginRequest): Result<LoginResponse, DataError.Remote> {
         return safeCall<LoginResponse> {
-            client.post("$BASE_URL/login") {
+            client.post("login") {
                 setBody(request)
             }
         }

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/di/Modules.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/di/Modules.kt
@@ -29,7 +29,7 @@ import org.koin.dsl.module
 expect val platformModule: Module
 
 val sharedModule = module {
-    single { HttpClientFactory.create(get()) }
+    single { HttpClientFactory.create(get(), get()) }
     singleOf(::KtorClient).bind<ApiService>()
     singleOf(::SplashRepositoryImpl)
     singleOf(::AuthRemoteDataSourceImpl).bind<AuthRemoteDataSource>()

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/network/ApiService.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/network/ApiService.kt
@@ -25,11 +25,11 @@ interface ApiService {
 
     suspend fun updatePassword(userId: String, request: ChangePasswordRequest): Result<ChangePasswordResponse, DataError.Remote>
 
-    suspend fun getWallets(token: String): Result<GetWalletsResponse, DataError.Remote>
+    suspend fun getWallets(): Result<GetWalletsResponse, DataError.Remote>
 
-    suspend fun getCategories(token: String): Result<GetCategoriesResponse, DataError.Remote>
+    suspend fun getCategories(): Result<GetCategoriesResponse, DataError.Remote>
 
-    suspend fun getTransactions(token: String): Result<GetTransactionsResponse, DataError.Remote>
+    suspend fun getTransactions(): Result<GetTransactionsResponse, DataError.Remote>
 
-    suspend fun postWallet(token: String, request: PostWalletRequest): Result<PostWalletResponse, DataError.Remote>
+    suspend fun postWallet(request: PostWalletRequest): Result<PostWalletResponse, DataError.Remote>
 }

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/network/HttpClientFactory.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/network/HttpClientFactory.kt
@@ -1,9 +1,11 @@
 package id.my.sendiko.fintrack.core.network
 
+import id.my.sendiko.fintrack.core.preferences.PreferencesRepositoryImpl
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -13,11 +15,15 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.serialization.json.Json
 
 object HttpClientFactory {
 
-    fun create(engine: HttpClientEngine): HttpClient {
+    fun create(
+        engine: HttpClientEngine,
+        preferences: PreferencesRepositoryImpl
+    ): HttpClient {
         return HttpClient(engine) {
             install(Logging) {
                 level = LogLevel.BODY
@@ -49,11 +55,15 @@ object HttpClientFactory {
             }
             install(Auth) {
                 bearer {
-                    // TODO: Load tokens
+                    loadTokens {
+                        val token = preferences.getToken().firstOrNull()
+                        if (!token.isNullOrBlank()) BearerTokens(token, "") else null
+                    }
                 }
             }
             defaultRequest {
                 contentType(ContentType.Application.Json)
+                url(BASE_URL)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/network/KtorClient.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/core/network/KtorClient.kt
@@ -15,21 +15,20 @@ import id.my.sendiko.fintrack.wallet.core.data.dto.getdetails.GetWalletsResponse
 import id.my.sendiko.fintrack.wallet.create.data.PostWalletRequest
 import id.my.sendiko.fintrack.wallet.create.data.PostWalletResponse
 import io.ktor.client.HttpClient
-import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 
-const val BASE_URL = "https://fintrack.sendiko.my.id"
+const val BASE_URL = "https://fintrack.sendiko.my.id/"
 
 class KtorClient(
     private val client: HttpClient
-): ApiService {
+) : ApiService {
     override suspend fun register(request: RegisterRequest): Result<RegisterResponse, DataError.Remote> {
         return safeCall<RegisterResponse> {
-            client.post("$BASE_URL/register") {
+            client.post("register") {
                 setBody(request)
             }
         }
@@ -37,7 +36,7 @@ class KtorClient(
 
     override suspend fun login(request: LoginRequest): Result<LoginResponse, DataError.Remote> {
         return safeCall<LoginResponse> {
-            client.post("$BASE_URL/login") {
+            client.post("login") {
                 setBody(request)
             }
         }
@@ -45,51 +44,44 @@ class KtorClient(
 
     override suspend fun searchUser(email: String): Result<SearchUserResponse, DataError.Remote> {
         return safeCall<SearchUserResponse> {
-            client.get("$BASE_URL/users") {
+            client.get("users") {
                 parameter("email", email)
             }
         }
     }
 
-    override suspend fun updatePassword(userId: String, request: ChangePasswordRequest): Result<ChangePasswordResponse, DataError.Remote> {
+    override suspend fun updatePassword(
+        userId: String,
+        request: ChangePasswordRequest
+    ): Result<ChangePasswordResponse, DataError.Remote> {
         return safeCall<ChangePasswordResponse> {
-            client.put("$BASE_URL/user/change-password/$userId") {
+            client.put("user/change-password/$userId") {
                 setBody(request)
             }
         }
     }
 
-    override suspend fun getWallets(token: String): Result<GetWalletsResponse, DataError.Remote> {
+    override suspend fun getWallets(): Result<GetWalletsResponse, DataError.Remote> {
         return safeCall<GetWalletsResponse> {
-            client.get("$BASE_URL/wallets") {
-                bearerAuth(token)
-            }
+            client.get("wallets")
         }
     }
 
-    override suspend fun getCategories(token: String): Result<GetCategoriesResponse, DataError.Remote> {
+    override suspend fun getCategories(): Result<GetCategoriesResponse, DataError.Remote> {
         return safeCall<GetCategoriesResponse> {
-            client.get("$BASE_URL/categories") {
-                bearerAuth(token)
-            }
+            client.get("categories")
         }
     }
 
-    override suspend fun getTransactions(token: String): Result<GetTransactionsResponse, DataError.Remote> {
+    override suspend fun getTransactions(): Result<GetTransactionsResponse, DataError.Remote> {
         return safeCall<GetTransactionsResponse> {
-            client.get("$BASE_URL/transactions") {
-                bearerAuth(token)
-            }
+            client.get("transactions")
         }
     }
 
-    override suspend fun postWallet(
-        token: String,
-        request: PostWalletRequest
-    ): Result<PostWalletResponse, DataError.Remote> {
+    override suspend fun postWallet(request: PostWalletRequest): Result<PostWalletResponse, DataError.Remote> {
         return safeCall<PostWalletResponse> {
-            client.post("$BASE_URL/wallets") {
-                bearerAuth(token)
+            client.post("wallets") {
                 setBody(request)
             }
         }

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/dashboard/data/DashboardRepository.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/dashboard/data/DashboardRepository.kt
@@ -18,16 +18,16 @@ class DashboardRepository(
         return prefs.getToken()
     }
 
-    suspend fun getWallets(token: String): Result<GetWalletsResponse, DataError.Remote> {
-        return ktorClient.getWallets(token)
+    suspend fun getWallets(): Result<GetWalletsResponse, DataError.Remote> {
+        return ktorClient.getWallets()
     }
 
-    suspend fun getCategories(token: String): Result<GetCategoriesResponse, DataError.Remote> {
-        return ktorClient.getCategories(token)
+    suspend fun getCategories(): Result<GetCategoriesResponse, DataError.Remote> {
+        return ktorClient.getCategories()
     }
 
-    suspend fun getTransactions(token: String): Result<GetTransactionsResponse, DataError.Remote> {
-        return ktorClient.getTransactions(token)
+    suspend fun getTransactions(): Result<GetTransactionsResponse, DataError.Remote> {
+        return ktorClient.getTransactions()
     }
 
     fun getUserId(): Flow<String> {

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/dashboard/presentation/DashboardViewModel.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/dashboard/presentation/DashboardViewModel.kt
@@ -40,7 +40,7 @@ class DashboardViewModel(
     private fun fetchData() {
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true) }
-            repository.getWallets(state.value.token)
+            repository.getWallets()
                 .onSuccess { result ->
                     val wallets = result.wallets.map { walletsItem ->
                         Wallet(
@@ -67,7 +67,7 @@ class DashboardViewModel(
                         )
                     }
                 }
-            repository.getCategories(state.value.token)
+            repository.getCategories()
                 .onSuccess { result ->
                     val categories = result.categories.map { category ->
                         Category(
@@ -107,7 +107,7 @@ class DashboardViewModel(
                         )
                     }
                 }
-            repository.getTransactions(state.value.token)
+            repository.getTransactions()
                 .onSuccess { result ->
                     val transactions = result.transactions
                     transactions.map { it ->

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/wallet/core/data/WalletRepository.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/wallet/core/data/WalletRepository.kt
@@ -15,11 +15,11 @@ class WalletRepository(
     val prefs: PreferencesRepositoryImpl
 ) {
 
-    suspend fun getWallets(token: String): Result<GetWalletsResponse, DataError.Remote> {
-        return ktorClient.getWallets(token)
+    suspend fun getWallets(): Result<GetWalletsResponse, DataError.Remote> {
+        return ktorClient.getWallets()
     }
 
-    suspend fun createWallet(token: String, userId: String, wallet: Wallet): Result<PostWalletResponse, DataError.Remote> {
+    suspend fun createWallet(userId: String, wallet: Wallet): Result<PostWalletResponse, DataError.Remote> {
         val request = PostWalletRequest(
             balance = wallet.amount,
             purpose = wallet.purpose,
@@ -27,7 +27,7 @@ class WalletRepository(
             type = wallet.type,
             userId = userId,
         )
-        return ktorClient.postWallet(token, request)
+        return ktorClient.postWallet(request)
     }
 
     fun getUserId(): Flow<String> {

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/wallet/create/presentation/CreateWalletViewModel.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/wallet/create/presentation/CreateWalletViewModel.kt
@@ -42,7 +42,6 @@ class CreateWalletViewModel(
         _state.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             val userId = state.value.userId
-            val token = state.value.token
             val wallet = Wallet(
                 id = "",
                 name = state.value.name,
@@ -52,7 +51,7 @@ class CreateWalletViewModel(
                 number = state.value.number
             )
             repository
-                .createWallet(token, userId, wallet)
+                .createWallet(userId, wallet)
                 .onSuccess { result ->
                     _state.update {
                         it.copy(

--- a/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/wallet/list/presentation/WalletListViewModel.kt
+++ b/shared/src/commonMain/kotlin/id/my/sendiko/fintrack/wallet/list/presentation/WalletListViewModel.kt
@@ -39,7 +39,7 @@ class WalletListViewModel(
     private fun loadData() {
         _state.update { it.copy(isLoading = true) }
         viewModelScope.launch {
-            repository.getWallets(state.value.token)
+            repository.getWallets()
                 .onSuccess { result ->
                     val wallets = result.wallets.map { walletItem ->
                         Wallet(


### PR DESCRIPTION
This commit refactors the networking layer to handle authentication tokens centrally using Ktor's Auth plugin. It also simplifies API calls by configuring a base URL and relative paths, removing the need to manually pass tokens through ViewModels and Repositories.

- **HttpClientFactory.kt**:
    - Updated `create` to accept `PreferencesRepositoryImpl`.
    - Implemented `loadTokens` within the Bearer Auth configuration to automatically retrieve the token from preferences.
    - Configured `defaultRequest` with the `BASE_URL` and JSON content type.
- **KtorClient.kt & ApiService.kt**:
    - Removed `token` parameters from `getWallets`, `getCategories`, `getTransactions`, and `postWallet`.
    - Simplified request functions to use relative paths (e.g., `client.post("register")` instead of full URL strings).
    - Removed manual `bearerAuth(token)` calls as they are now handled by the Auth plugin.
- **Repositories**:
    - Updated `WalletRepository` and `DashboardRepository` to reflect changes in `ApiService`, removing token propagation.
- **ViewModels**:
    - Updated `WalletListViewModel`, `DashboardViewModel`, and `CreateWalletViewModel` to call repository methods without passing the token from the UI state.
- **Modules.kt**:
    - Updated Koin module to provide `PreferencesRepositoryImpl` to `HttpClientFactory`.